### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ $ cd ~/.config/sublime-text-2/Packages
 $ git clone https://github.com/joneshf/sublime-grasp
 ```
 
-#### Macosx (untested)
+#### Macosx
 
 ```
-$ cd "~/Library/Application Support/Sublime Text 2/Packages"
+$ cd ~/Library/Application\ Support/Sublime\ Text\ 2/Packages/
 $ git clone https://github.com/joneshf/sublime-grasp
 ```
 


### PR DESCRIPTION
Tested the osx manual install and updated the cd command. If installed in the default location this should work for sublime text 2 and for 3 obviously the number just needs changing.
